### PR TITLE
Allow usage with self-hosted bot

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -45,7 +45,8 @@ function App () {
   }
 
   function connectToGame () {
-    const newSocket = openSocket(process.env.REACT_APP_SYNC_SERVER_ADDRESS || 'localhost:8081')
+    const url = new URL(window.location.href);
+    const newSocket = openSocket(url.searchParams.get('bot_url') || process.env.REACT_APP_SYNC_SERVER_ADDRESS || 'localhost:8081')
 
     setLoading(true)
 


### PR DESCRIPTION
This little change allows people to use the WebApp together with their self-hosted version of [Amongcord](https://github.com/pedrofracassi/amongcord) by adding `?bot_url=<url_of_the_bot>` to the link.

I am not sure, but as far as I can see, this does not open further security/exploitation issues.
Correct me if I'm wrong.